### PR TITLE
Groovy doesn't have a -w flag.

### DIFF
--- a/snippets/language-groovy.cson
+++ b/snippets/language-groovy.cson
@@ -1,7 +1,7 @@
 '.source.groovy':
-  '#!/usr/bin/env groovy -w':
+  '#!/usr/bin/env groovy':
     'prefix': '#!'
-    'body': '#!/usr/bin/env groovy -w\n\n'
+    'body': '#!/usr/bin/env groovy\n\n'
   'replace(dir: …, includes: …, token: …, value: …)':
     'prefix': 'replace'
     'body': 'replace(dir:"${1:dirName}", includes:"${2:*.*}", token:"${3:tokenName}", value:"\\${${4:value}}")$0'


### PR DESCRIPTION
I'm just getting into Atom and your excellent language-groovy was one of the first packages I played with.  I noticed one problem with the she-bang snippet.  It refers to a non-existent `-w` flag.
